### PR TITLE
Stop refreshing tokens and ensure sendMail callbacks are called when manually closing a transport

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -63,6 +63,10 @@ function SMTPClient(port, host, options) {
     this.options.maxConnections = this.options.maxConnections || 5;
     this.options.enableDotEscaping = this.options.enableDotEscaping || false;
 
+    if (this.options.instanceId) {
+        this.options.instanceId = process.pid + '-' + this.options.instanceId
+    }
+
     this._closing = false;
 
     if (!this.options.name) {
@@ -406,7 +410,6 @@ SMTPClient.prototype._onClose = function() {
  */
 SMTPClient.prototype._onEnd = function() {
     this.stage = 'end';
-
     this._destroy();
 };
 
@@ -539,7 +542,7 @@ SMTPClient.prototype.close = function() {
     this._closing = true;
 
     if (this.options.debug) {
-        console.log('Closing connection to the server');
+        console.log('Closing connection to the server', this.options.instanceId);
     }
 
     if (this.options.logFile) {
@@ -902,11 +905,16 @@ SMTPClient.prototype._actionAUTHComplete = function(str) {
         try {
             response = str.split(' ');
             response.shift();
-            response = JSON.parse(new Buffer(response.join(' '), 'base64').toString('utf-8'));
-
-            if ((!this._xoauth2.reconnectCount || this._xoauth2.reconnectCount < 200) && ['400', '401'].indexOf(response.status) >= 0) {
+            responseString = new Buffer(response.join(' '), 'base64').toString('utf-8')
+            response = JSON.parse(responseString);
+            if (+response.status === 400 && response.schemes === 'Bearer') {
+                this._onError(new Error('Invalid login - Access token expired: ' + responseString), 'AuthError', response);
+                return;
+            } else if ((!this._xoauth2.reconnectCount || this._xoauth2.reconnectCount < 200) && ['400', '401'].indexOf(response.status) >= 0) {
                 this._xoauth2.reconnectCount = (this._xoauth2.reconnectCount || 0) + 1;
-                this._currentAction = this._actionXOAUTHRetry;
+                console.log('**** Unexpected logic branch encountered', this._xoauth2.reconnectCount, str, response)
+                this._onError(new Error('Invalid login - ' + responseString), 'AuthError', response);
+                return;
             } else {
                 this._xoauth2.reconnectCount = 0;
                 this._currentAction = this._actionAUTHComplete;
@@ -927,29 +935,6 @@ SMTPClient.prototype._actionAUTHComplete = function(str) {
     }
 
     this._enterIdle();
-};
-
-/**
- * If XOAUTH2 authentication failed, try again by generating
- * new access token
- */
-SMTPClient.prototype._actionXOAUTHRetry = function() {
-
-    // ensure that something is listening unexpected responses
-    this._currentAction = this._actionIdle;
-
-    this._xoauth2.generateToken((function(err, token) {
-        if (this._destroyed) {
-            // Nothing to do here anymore, connection already closed
-            return;
-        }
-        if (err) {
-            this._onError(err, 'XOAUTH2Error');
-            return;
-        }
-        this._currentAction = this._actionAUTHComplete;
-        this.sendCommand('AUTH XOAUTH2 ' + token);
-    }).bind(this));
 };
 
 /**

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -367,7 +367,9 @@ SMTPConnectionPool.prototype._onConnectionEnd = function(connection) {
 
     // Call the current message's callback if one still exists
     // This is important to do here and in _onConnectionError because
-    // _onConnectionEnd() can be called without _onConnectionError being called
+    // _onConnectionEnd() can be called without _onConnectionError being called.
+    // If this is not done, callbacks passed to sendMail() will not be called for
+    // messages that are in-flight at the time the connection is closed.
     var message = connection.currentMessage;
     connection.currentMessage = false;
     if (message && message.returnCallback) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -365,6 +365,18 @@ SMTPConnectionPool.prototype._onConnectionEnd = function(connection) {
         }
     }
 
+    // Call the current message's callback if one still exists
+    // This is important to do here and in _onConnectionError because
+    // _onConnectionEnd() can be called without _onConnectionError being called
+    var message = connection.currentMessage;
+    connection.currentMessage = false;
+    if (message && message.returnCallback) {
+        var error = new Error('Message delivery temporarily failed. Connection closed during send. Please retry');
+        error.name = 'DeliveryError';
+        error.data = message;
+        message.returnCallback(error);
+    }
+
     // if there's still unprocessed mail and available connection slots, create
     // a new connection
     if (this._messageQueue.length &&


### PR DESCRIPTION
f67764f25c2e 
Ensure inflight messages have their callback called when a connection is manually closed. Previously, we were only clearing inflight messages if an error was encountered. This led to the possibility of sendMail callbacks not being called if connection.close() was called without an error ocurring

d95a1d103b95
Remove the ability for simplesmtp to automatically refresh tokens when encountering an auth error