### PR TITLE
Ignore and warn on ECONNRESET errors that would have been unhandled.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -378,7 +378,7 @@ SMTPClient.prototype._onError = function(err, type, data) {
     err.stage = this.stage;
     // If we receive an ECONNRESET error and there are no error listeners,
     // we can assume the connection is no longer needed and the error
-    // can be ignored
+    // can be ignored.
     if ((err.code === 'ECONNRESET') && (this.listenerCount('error') === 0)) {
         var logMessage = {
             name: 'simplesmtp',
@@ -386,6 +386,12 @@ SMTPClient.prototype._onError = function(err, type, data) {
             level: 50,
             smtpClientOptions: this.options,
             stack: (new Error()).stack,
+            smtpClientState: {
+                stage: this.stage,
+                _destroyed: this._destroyed,
+                _closing: this._closing,
+                _ignoreData: this._ignoreData
+            },
             err: {
                 message: err.message,
                 code: err.code,

--- a/lib/client.js
+++ b/lib/client.js
@@ -314,7 +314,9 @@ SMTPClient.prototype._destroy = function() {
     this.emit('end');
     this.removeAllListeners();
     // keep the error handler around, just in case
-    this.socket.on('error', this._onError.bind(this));
+    if (this.socket) {
+        this.socket.on('error', this._onError.bind(this));
+    }
 };
 
 /**
@@ -374,6 +376,29 @@ SMTPClient.prototype._onError = function(err, type, data) {
         err.data = data;
     }
     err.stage = this.stage;
+    // If we receive an ECONNRESET error and there are no error listeners,
+    // we can assume the connection is no longer needed and the error
+    // can be ignored
+    if ((err.code === 'ECONNRESET') && (this.listenerCount('error') === 0)) {
+        var logMessage = {
+            name: 'simplesmtp',
+            pid: process.pid,
+            level: 50,
+            err: {
+                message: err.message,
+                code: err.code,
+                stack: err.stack,
+                name: err.name
+            },
+            msg: 'Ignorable ECONNRESET error from simplesmtp detected'
+        }
+        console.log(JSON.stringify(logMessage))
+        // Close the client if its not already destroyed or in the process of closing
+        if (!this._destroyed && !this._closing) {
+            this.close();
+        }
+        return
+    }
     this.emit('error', err);
     this.close();
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -310,6 +310,7 @@ SMTPClient.prototype._destroy = function() {
         return;
     }
     this._destroyed = true;
+    this._destroyedAt = Date.now();
     this._ignoreData = true;
     this.emit('end');
     this.removeAllListeners();
@@ -389,6 +390,7 @@ SMTPClient.prototype._onError = function(err, type, data) {
             smtpClientState: {
                 stage: this.stage,
                 _destroyed: this._destroyed,
+                _destroyedAt: this._destroyedAt,
                 _closing: this._closing,
                 _ignoreData: this._ignoreData
             },
@@ -400,7 +402,7 @@ SMTPClient.prototype._onError = function(err, type, data) {
             },
             msg: 'Ignorable ECONNRESET error from simplesmtp detected'
         }
-        console.log(JSON.stringify(logMessage))
+        console.log(utillib.inspect(logMessage, {breakLength: Infinity, colors: false}))
         // Close the client if its not already destroyed or in the process of closing
         if (!this._destroyed && !this._closing) {
             this.close();

--- a/lib/client.js
+++ b/lib/client.js
@@ -384,6 +384,8 @@ SMTPClient.prototype._onError = function(err, type, data) {
             name: 'simplesmtp',
             pid: process.pid,
             level: 50,
+            smtpClientOptions: this.options,
+            stack: (new Error()).stack,
             err: {
                 message: err.message,
                 code: err.code,

--- a/package.json
+++ b/package.json
@@ -2,22 +2,22 @@
     "name": "simplesmtp",
     "description": "Simple SMTP server module to create custom SMTP servers",
     "version": "0.3.35",
-    "author" : "Andris Reinman",
-    "maintainers":[
+    "author": "Andris Reinman",
+    "maintainers": [
         {
-            "name":"andris",
-            "email":"andris@node.ee"
+            "name": "andris",
+            "email": "andris@node.ee"
         }
     ],
-    "repository" : {
-        "type" : "git",
-        "url" : "http://github.com/andris9/simplesmtp.git"
+    "repository": {
+        "type": "git",
+        "url": "http://github.com/andris9/simplesmtp.git"
     },
-    "scripts":{
+    "scripts": {
         "test": "nodeunit test/"
     },
-    "main" : "./lib/smtp",
-    "licenses" : [
+    "main": "./lib/smtp",
+    "licenses": [
         {
             "type": "MIT",
             "url": "http://github.com/andris9/simplesmtp/blob/master/LICENSE"
@@ -31,6 +31,15 @@
         "nodeunit": "*",
         "mailcomposer": "*"
     },
-    "engines" : { "node" : ">=0.8.0" },
-    "keywords": ["servers", "text-based", "smtp", "email", "mail", "e-mail"]
+    "engines": {
+        "node": ">=0.8.0"
+    },
+    "keywords": [
+        "servers",
+        "text-based",
+        "smtp",
+        "email",
+        "mail",
+        "e-mail"
+    ]
 }


### PR DESCRIPTION
I believe the likely path that led to the condition being checked here is that a client gets `_destroy()` called on it, via a call to `close()`. At this time, it removes all listeners on the smtpclient instance, but also rebinds the error handler of the underlying `socket` to the `_onError()`. 

When the socket emits an error, the _onError handler is invoked, the error is re-emitted on the client instance itself. However, because the client instance has already had all of its listeners removed, its guaranteed to result in an uncaughtException. 

In such cases, it seems okay to ignore the ECONNRESET error, since the client instance has already been destroyed. 

The logging added here will allow us to confirm this theory definitively. 